### PR TITLE
Change modifier key for Dial's velocity mode to shift

### DIFF
--- a/Source/GUIv2/dial/Dial.cpp
+++ b/Source/GUIv2/dial/Dial.cpp
@@ -18,8 +18,8 @@ Dial::Dial (std::string const& labelText,
     mSlider.setColour (juce::Slider::textBoxOutlineColourId, juce::Colours::grey);
     mSlider.setColour (juce::Slider::rotarySliderFillColourId, juce::Colours::blue);
     mSlider.setLookAndFeel (&mLookAndFeel);
-
-    mSlider.setTextBoxIsEditable (true);
+    mSlider.setVelocityModeParameters (1.0, 1, 0.02, true, juce::ModifierKeys::shiftModifier);
+    mSlider.setTextBoxIsEditable (false);
     // mSlider.setTextValueSuffix (" dB");
 
     // mSlider.setVelocityBasedMode (true);


### PR DESCRIPTION
- All dial's modifier key for velocity mode has been changed to "shift"(instead of ctrl)
- Velocity mode sensitivity has been adjusted