### PR TITLE
Switch to STL tanh implementation to avoid peaks

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.env import VirtualBuildEnv
 
 class PeakEater(ConanFile):
     name = "peakeater"
-    version = "0.7.1"
+    version = "0.7.2"
     user = "vvvar"
     channel = "testing"
     company = "T-Audio"

--- a/source/DSP/ClippingFunctions.h
+++ b/source/DSP/ClippingFunctions.h
@@ -40,7 +40,7 @@ namespace dsp
         T tanclip (T x) noexcept
         {
             float soft = 0.0f;
-            return JMath::tanh ((1.0f - 0.5f * soft) * x);
+            return std::tanh ((1.0f - 0.5f * soft) * x);
         }
 
         template <typename T>


### PR DESCRIPTION
JMATH implementation of tanh seems passes peaks on high values. Switch STL implementation instead.